### PR TITLE
Update file mover to use a generic kafka topic & additional logic for automating new downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: bash
+arch:
+  - amd64
+services:
+  - docker
+jobs:
+  include:
+    - stage: build branch
+      script:
+        - set -e
+        - docker build -t chrisjohnson00/handbrake-file-mover -f Dockerfile .
+        - docker run chrisjohnson00/handbrake-file-mover python -m flake8
+        - docker run chrisjohnson00/handbrake-file-mover python -m pytest
+        - docker login --username=chrisjohnson00 --password=$DOCKER_HUB_PASSWORD
+        - docker tag chrisjohnson00/handbrake_webhook chrisjohnson00/handbrake-file-mover:$TRAVIS_BRANCH
+        - docker push chrisjohnson00/handbrake-file-mover:$TRAVIS_BRANCH
+      if: tag is blank
+    - stage: build tag
+      script:
+        - docker build -t chrisjohnson00/handbrake-file-mover -f Dockerfile .
+        - docker login --username=chrisjohnson00 --password=$DOCKER_HUB_PASSWORD
+        - docker tag chrisjohnson00/handbrake_webhook chrisjohnson00/handbrake-file-mover:$TRAVIS_TAG
+        - docker push chrisjohnson00/handbrake-file-mover:$TRAVIS_TAG
+        - docker push chrisjohnson00/handbrake-file-mover
+      if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ jobs:
         - docker run chrisjohnson00/handbrake-file-mover python -m flake8
         - docker run chrisjohnson00/handbrake-file-mover python -m pytest
         - docker login --username=chrisjohnson00 --password=$DOCKER_HUB_PASSWORD
-        - docker tag chrisjohnson00/handbrake_webhook chrisjohnson00/handbrake-file-mover:$TRAVIS_BRANCH
+        - docker tag chrisjohnson00/handbrake-file-mover chrisjohnson00/handbrake-file-mover:$TRAVIS_BRANCH
         - docker push chrisjohnson00/handbrake-file-mover:$TRAVIS_BRANCH
       if: tag is blank
     - stage: build tag
       script:
         - docker build -t chrisjohnson00/handbrake-file-mover -f Dockerfile .
         - docker login --username=chrisjohnson00 --password=$DOCKER_HUB_PASSWORD
-        - docker tag chrisjohnson00/handbrake_webhook chrisjohnson00/handbrake-file-mover:$TRAVIS_TAG
+        - docker tag chrisjohnson00/handbrake-file-mover chrisjohnson00/handbrake-file-mover:$TRAVIS_TAG
         - docker push chrisjohnson00/handbrake-file-mover:$TRAVIS_TAG
         - docker push chrisjohnson00/handbrake-file-mover
       if: tag IS present

--- a/app.py
+++ b/app.py
@@ -130,13 +130,15 @@ def get_config(key, config_path=CONFIG_PATH):
 
 def copy_file(src, dest):
     command = ["cp", src, dest]
-    print("File copy command called {}".format(command), flush=True)
+    print("INFO: {} - File copy command called {}".format(datetime.now().strftime("%b %d %H:%M:%S"), command),
+          flush=True)
     subprocess.run(command, check=True)
 
 
 def move_file(src, dest):
     command = ["mv", src, dest]
-    print("File move command called {}".format(command), flush=True)
+    print("INFO: {} - File move command called {}".format(datetime.now().strftime("%b %d %H:%M:%S"), command),
+          flush=True)
     subprocess.run(command, check=True)
 
 


### PR DESCRIPTION
With the addition of the handbrake-webhook server, this moves to a generic kafka topic for all file move operations.
This adds logic for moving files into the encoding pipeline, and tweaks the handling of how moves/copies happen on the output of the encoding pipeline.